### PR TITLE
Speed up

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ extensions = [Extension("qoi.qoi", sources=["src/qoi/qoi.pyx", "src/qoi/implemen
 
 
 if USE_CYTHON:
-    compiler_directives = {"language_level": 3, "embedsignature": True, "boundscheck": False, "wraparound": False}
+    compiler_directives = {"language_level": 3, "embedsignature": True, "boundscheck": False, "wraparound": False, "cdivision": True}
     extensions = cythonize(extensions, compiler_directives=compiler_directives)
 else:
     extensions = no_cythonize(extensions)

--- a/tests/test_qoi.py
+++ b/tests/test_qoi.py
@@ -38,6 +38,23 @@ def test_encode_decode(colorspace: qoi.QOIColorSpace, is_rgba: bool):
     assert np.array_equal(img, img_decoded)
 
 
+@pytest.mark.parametrize("is_rgba", [True, False])
+@pytest.mark.parametrize("colorspace", [qoi.QOIColorSpace.SRGB, qoi.QOIColorSpace.LINEAR, None])
+def test_encode_decode_with_colorspace(colorspace: qoi.QOIColorSpace, is_rgba: bool):
+    img = RGBA if is_rgba else RGB
+    if colorspace is None:
+        bites = qoi.encode(img)
+    else:
+        bites = qoi.encode(img, colorspace)
+    data = bytearray(1)
+    img_decoded = qoi.decode(bites, colorspace=data)
+    if colorspace is not None:
+        assert data[0] == colorspace.value
+    else:
+        assert data[0] == qoi.QOIColorSpace.SRGB.value
+    assert np.array_equal(img, img_decoded)
+
+
 def test_version():
     assert qoi.__version__ is not None
 


### PR DESCRIPTION
# This pr did:
- Use typed memory view to speed up with all bufferd protocol objects support
- PyMem_Malloc and PyMem_Free to speed up memory alloc
-  handled desc.colorspace without any breaking change
- update submodule

It passed all tests on my machine.