### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "wheel >= 0.30.0",
     "setuptools_scm >= 6.2",
     "Cython>=0.29.33",
-    "numpy>=1.21.6;",
+    "numpy>=1.21.6",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Unwanted semicolon caused a warning and failed installing qoi.

> This package has an invalid `build-system.requires` key in pyproject.toml.

Thanks [@Pixel-Therapy](https://github.com/Pixel-Therapy) for noticing this!