### PR TITLE
Prepare for Cython 3.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-Cython
+Cython>=3.0.0
 pytest
 build
 twine

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ extensions = [
     Extension(
         "qoi.qoi",
         sources=["src/qoi/qoi.pyx", "src/qoi/implementation.c"],
-        define_macros=[("QOI_MALLOC", "PyMem_Malloc"), ("QOI_FREE", "PyMem_Free")],
+        define_macros=[("QOI_MALLOC", "PyMem_Malloc"), ("QOI_FREE", "PyMem_Free"), ("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
     )
 ]
 

--- a/src/qoi/qoi.pyx
+++ b/src/qoi/qoi.pyx
@@ -1,7 +1,6 @@
 cimport qoi.qoi as qoi
 import numpy as np
 cimport numpy as np
-from cpython cimport PyObject, Py_INCREF
 from cpython.mem cimport PyMem_Free
 import enum
 from pathlib import Path
@@ -23,8 +22,7 @@ cdef class PixelWrapper:
         self.pixels = pixels
         shape[:] = (height, width, channels)
         ndarray = np.PyArray_SimpleNewFromData(3, shape, np.NPY_UINT8, self.pixels)
-        ndarray.base = <PyObject*> self
-        Py_INCREF(self)
+        np.set_array_base(ndarray, self)
         return ndarray
 
     def __dealloc__(self):


### PR DESCRIPTION
Cython have released their latest version 3.0 with many bugs fixed and new features. Now compatibility warning at compile time is gone. And this patch update bundled qoi to the latest version.