### PR TITLE
Update cibuildwheel to 2.16.2

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -48,7 +48,7 @@ jobs:
           fetch-depth: 0 # Optional, use if you use setuptools_scm https://stackoverflow.com/a/68959339
           submodules: true # Optional, use if you have submodules
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.3.1
+        uses: pypa/cibuildwheel@v2.16.2
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl


### PR DESCRIPTION
Version 2.3.1 sets a constraint: `setuptools==59.6.0`

If we want to use `setuptools>=60` then we need to use at minimum `cibuildwheel` 2.4.0. I propose we update to the latest since it supports Python 3.8 and up to 3.12