### PR TITLE
Update  MacOS runner `macos-10.15` to `macos-12`

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-12]
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
macos-10.15 has been deprecated and removed.

See https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/

> Workflows using the macos-10.15 YAML workflow label should be updated to macos-11, macos-12, or macos-latest