### PR TITLE
init support for freethreading

### DIFF
--- a/src/qoi/qoi.pyx
+++ b/src/qoi/qoi.pyx
@@ -4,6 +4,7 @@ cimport numpy as np
 from cpython.mem cimport PyMem_RawFree
 import enum
 from pathlib import Path
+cimport cython
 
 np.import_array()
 
@@ -13,6 +14,7 @@ class QOIColorSpace(enum.Enum):
     SRGB = qoi.QOI_SRGB
     LINEAR = qoi.QOI_LINEAR
 
+@cython.internal
 cdef class PixelWrapper:
     cdef void* pixels
 


### PR DESCRIPTION
CPython has released a nogil version, luckly, cython catch up soon, so we can release a version that compatible with it.
According to the [docs](https://cython.readthedocs.io/en/latest/src/userguide/freethreading.html), compile it on windows would be something like ```python -Xgil=0 setup.py bdist_wheel```