### PR TITLE
add qoi-rs benchmark

### DIFF
--- a/src/qoi/benchmark.py
+++ b/src/qoi/benchmark.py
@@ -90,7 +90,7 @@ def bench_qoi(rgb, test_name, warmup=3, tests=10):
 
 
 def bench_qoi_rs(rgb, test_name, warmup=3, tests=10):
-    encode_ms, bites = timeit(lambda: qoi_rs.encode(rgb.tobytes(), width=1920, height=1080), warmup=warmup, tests=tests)
+    encode_ms, bites = timeit(lambda: qoi_rs.encode(rgb.tobytes(), height=rgb.shape[0], width=rgb.shape[1]), warmup=warmup, tests=tests)
     decode_ms, decoded = timeit(lambda: qoi_rs.decode(bites), warmup=warmup, tests=tests)
     yield TestResult(
         "qoi_rs",


### PR DESCRIPTION
Made my one library because I'm not in the numpy ecosystem and wanted an alternative using more normal python datatypes. Performance seems to be similar.



| Test image                | Method              | Format   | Input (kb) | Encode (ms) | Encode (kb) | Decode (ms) | SSIM |
| ------------------------- | ------------------- | -------- | ---------- | ----------- | ----------- | ----------- | ---- |
| all black ('best' case)   | PIL                 | jpg @ 80 | 6075.0     | 2.26        | 32.5        | 2.52        | 1.00 |
| all black ('best' case)   | PIL                 | png      | 6075.0     | 16.44       | 6.0         | 10.51       | 1.00 |
| all black ('best' case)   | opencv              | jpg @ 80 | 6075.0     | 2.10        | 32.5        | 1.97        | 1.00 |
| all black ('best' case)   | opencv              | png      | 6075.0     | 8.82        | 7.7         | 12.65       | 1.00 |
| all black ('best' case)   | qoi                 | qoi      | 6075.0     | 2.08        | 32.7        | 1.23        | 1.00 |
| all black ('best' case)   | qoi-lossy-0.50x0.50 | qoi      | 6075.0     | 0.92        | 8.2         | 0.92        | 1.00 |
| all black ('best' case)   | qoi_rs              | qoi      | 6075.0     | 1.91        | 32.7        | 0.88        | 1.00 |
| koi photo                 | PIL                 | jpg @ 80 | 6075.0     | 3.47        | 274.6       | 5.34        | 0.94 |
| koi photo                 | PIL                 | png      | 6075.0     | 638.59      | 2821.5      | 35.79       | 1.00 |
| koi photo                 | opencv              | jpg @ 80 | 6075.0     | 2.99        | 275.3       | 3.62        | 0.94 |
| koi photo                 | opencv              | png      | 6075.0     | 44.85       | 3121.5      | 21.84       | 1.00 |
| koi photo                 | qoi                 | qoi      | 6075.0     | 13.93       | 3489.0      | 9.40        | 1.00 |
| koi photo                 | qoi-lossy-0.50x0.50 | qoi      | 6075.0     | 3.85        | 980.1       | 2.86        | 0.95 |
| koi photo                 | qoi_rs              | qoi      | 6075.0     | 10.78       | 3489.0      | 7.34        | 1.00 |
| random noise (worst case) | PIL                 | jpg @ 80 | 6075.0     | 6.46        | 1351.6      | 11.66       | 0.55 |
| random noise (worst case) | PIL                 | png      | 6075.0     | 160.09      | 6084.5      | 21.63       | 1.00 |
| random noise (worst case) | opencv              | jpg @ 80 | 6075.0     | 6.13        | 1351.7      | 9.75        | 0.55 |
| random noise (worst case) | opencv              | png      | 6075.0     | 29.66       | 6086.9      | 7.45        | 1.00 |
| random noise (worst case) | qoi                 | qoi      | 6075.0     | 8.46        | 8096.0      | 4.73        | 1.00 |
| random noise (worst case) | qoi-lossy-0.50x0.50 | qoi      | 6075.0     | 2.54        | 2019.1      | 2.23        | 0.24 |
| random noise (worst case) | qoi_rs              | qoi      | 6075.0     | 7.94        | 8096.0      | 3.36        | 1.00 |